### PR TITLE
Fixed a bug so require('js-priority-queue') works properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "js-priority-queue",
   "version": "0.1.0",
   "description": "Priority queue data structures",
-  "main": "index.js",
+  "main": "priority-queue.js",
   "scripts": {},
   "repository": {
     "type": "git",


### PR DESCRIPTION
Might not be the way you want to fix it but this pull request fixes a bug so `require('js-priority-queue')` works in node v0.10.31 and not just in CoffeeScript. In node the following error is thrown when you try to `require('js-priority-queue')`

```
> require('js-priority-queue')
Error: Cannot find module './src/PriorityQueue'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/freethenation/projects/poly-js/node_modules/js-priority-queue/index.js:1:80)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)

```
