### PR TITLE
added missing dependency for coffee-script / fixed handling of initialValues

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "browserify": "^11.0.0",
     "chai": "^3.1.0",
     "coffeeify": "^1.1.0",
+    "coffee-script": "^1.10.0",
     "del": "^1.2.0",
     "gulp": "^3.9.0",
     "gulp-coffee": "^2.3.1",

--- a/src/PriorityQueue/AbstractPriorityQueue.coffee
+++ b/src/PriorityQueue/AbstractPriorityQueue.coffee
@@ -3,7 +3,7 @@ module.exports = class AbstractPriorityQueue
     throw 'Must pass options.strategy, a strategy' if !options?.strategy?
     throw 'Must pass options.comparator, a comparator' if !options?.comparator?
     @priv = new options.strategy(options)
-    @length = 0
+    @length = @priv.data.length 
 
   queue: (value) ->
     @length++

--- a/test/PriorityQueueSpec.coffee
+++ b/test/PriorityQueueSpec.coffee
@@ -21,6 +21,13 @@ describe 'PriorityQueue', ->
     queue = new PriorityQueue(strategy: PriorityQueue.BinaryHeapStrategy)
     expect(queue.priv.comparator(2, 3)).to.equal(-1)
 
+describe 'integration tests with custom constructors', ->
+  it 'should enqueue all items in initialValues', ->
+    @queue = new PriorityQueue(initialValues: [3,1,2])
+    expect(@queue.dequeue()).to.equal(1)
+    expect(@queue.dequeue()).to.equal(2)
+    expect(@queue.dequeue()).to.equal(3)
+
 describe 'integration tests', ->
   beforeEach ->
     @queue = new PriorityQueue()


### PR DESCRIPTION
The target "gulp test" depends on coffee-script, but coffee-script was missing in packages.json. 
I manually ran a "npm install coffee-script" - this pulled in coffee-script v 1.10.0, and therefore, I added this version to packages.json - hope that's ok.

Kind regards,
Frank