### PR TITLE
fix usage with browserify

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -8,6 +8,7 @@ mocha = require('gulp-mocha')
 rename = require('gulp-rename')
 source = require('vinyl-source-stream')
 uglify = require('gulp-uglify')
+derequire = require('gulp-derequire')
 
 gulp.task 'clean', (done) ->
   del('./priority-queue*.js', done)
@@ -22,6 +23,7 @@ gulp.task 'browserify', [ 'clean' ], ->
   b.bundle()
     .on('error', (e) -> gutil.log('Browserify error', e))
     .pipe(source('priority-queue.js'))
+    .pipe(derequire())
     .pipe(gulp.dest('.'))
 
 gulp.task 'minify', [ 'browserify' ], ->

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "del": "^1.2.0",
     "gulp": "^3.9.0",
     "gulp-coffee": "^2.3.1",
+    "gulp-derequire": "^2.1.0",
     "gulp-mocha": "^2.1.3",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.2.0",

--- a/priority-queue.js
+++ b/priority-queue.js
@@ -1,15 +1,15 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.PriorityQueue = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.PriorityQueue = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
 var AbstractPriorityQueue, ArrayStrategy, BHeapStrategy, BinaryHeapStrategy, PriorityQueue,
   extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
   hasProp = {}.hasOwnProperty;
 
-AbstractPriorityQueue = require('./PriorityQueue/AbstractPriorityQueue');
+AbstractPriorityQueue = _dereq_('./PriorityQueue/AbstractPriorityQueue');
 
-ArrayStrategy = require('./PriorityQueue/ArrayStrategy');
+ArrayStrategy = _dereq_('./PriorityQueue/ArrayStrategy');
 
-BinaryHeapStrategy = require('./PriorityQueue/BinaryHeapStrategy');
+BinaryHeapStrategy = _dereq_('./PriorityQueue/BinaryHeapStrategy');
 
-BHeapStrategy = require('./PriorityQueue/BHeapStrategy');
+BHeapStrategy = _dereq_('./PriorityQueue/BHeapStrategy');
 
 PriorityQueue = (function(superClass) {
   extend(PriorityQueue, superClass);
@@ -36,7 +36,7 @@ PriorityQueue.BHeapStrategy = BHeapStrategy;
 module.exports = PriorityQueue;
 
 
-},{"./PriorityQueue/AbstractPriorityQueue":2,"./PriorityQueue/ArrayStrategy":3,"./PriorityQueue/BHeapStrategy":4,"./PriorityQueue/BinaryHeapStrategy":5}],2:[function(require,module,exports){
+},{"./PriorityQueue/AbstractPriorityQueue":2,"./PriorityQueue/ArrayStrategy":3,"./PriorityQueue/BHeapStrategy":4,"./PriorityQueue/BinaryHeapStrategy":5}],2:[function(_dereq_,module,exports){
 var AbstractPriorityQueue;
 
 module.exports = AbstractPriorityQueue = (function() {
@@ -83,7 +83,7 @@ module.exports = AbstractPriorityQueue = (function() {
 })();
 
 
-},{}],3:[function(require,module,exports){
+},{}],3:[function(_dereq_,module,exports){
 var ArrayStrategy, binarySearchForIndexReversed;
 
 binarySearchForIndexReversed = function(array, value, comparator) {
@@ -135,7 +135,7 @@ module.exports = ArrayStrategy = (function() {
 })();
 
 
-},{}],4:[function(require,module,exports){
+},{}],4:[function(_dereq_,module,exports){
 var BHeapStrategy;
 
 module.exports = BHeapStrategy = (function() {
@@ -286,7 +286,7 @@ module.exports = BHeapStrategy = (function() {
 })();
 
 
-},{}],5:[function(require,module,exports){
+},{}],5:[function(_dereq_,module,exports){
 var BinaryHeapStrategy;
 
 module.exports = BinaryHeapStrategy = (function() {


### PR DESCRIPTION
Hi! Since main file is a browserified bundle there is a problem upon attempt to browserify it within dependant bundle:
```Error: Cannot find module './PriorityQueue/BHeapStrategy' from 'bla-bla-bla/node_modules/js-priority-queue'```

There are several workarounds:

- point out a minified version as `main` file in `package.json`
- define treated by browserify `browser` section in `package.json` as follows
```json
"browser": {
    "./PriorityQueue/AbstractPriorityQueue": "./priority-queue.js",
    "./PriorityQueue/ArrayStrategy": "./priority-queue.js",
    "./PriorityQueue/BHeapStrategy": "./priority-queue.js",
    "./PriorityQueue/BinaryHeapStrategy": "./priority-queue.js"
  },
```
- add i.e. `lib` folder containing transpiled *.coffee files only, leaving browserified version for browser only
- use [derequire](https://www.npmjs.com/package/gulp-derequire) in order to prevent browserifying of already included modules as present PR suggests