### PR TITLE
Explicitly state in the README that BinaryHeapStrategy will be used by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ only if you're queuing items in a very particular order. Don't use
 `BHeapStrategy`, except as a lesson in how sometimes miracles in one
 programming language aren't great in other languages.
 
+If no strategy specified in parameters, the `BinaryHeapStrategy` will be used
+
 Contributing
 ============
 


### PR DESCRIPTION
Hi. Thanks for the lib. May we add this line in the README to make it clear how does it behave when no strategy parameter specified?